### PR TITLE
Improve the speed of read_mars

### DIFF
--- a/read_mars/__init__.py
+++ b/read_mars/__init__.py
@@ -58,6 +58,7 @@ def read_mars(filename, tree='Events', leaf_names=None):
 
     read_mars uses the TTree.Draw() function to prevent calling each leaf of each event
     with a lot of overhead from python. It also omits the useless leaves fBits and fUniqueID.
+    Files with MSignalCam containers (callisto output) can not be read.
     Keyword arguments:
     tree -- Set, which tree to read. (Default = "Events")
     leaf_names -- Specify a list of leaf_names. (Default is None, what reads in all leaf_names)

--- a/read_mars/__init__.py
+++ b/read_mars/__init__.py
@@ -49,8 +49,8 @@ def leaves_to_numpy(tree, leaf_names):
         tree.Draw(leaf_name, "", "goff")
         v1 = tree.GetV1()
         v1.SetSize(n_events * 8)  # a double has 8 Bytes
-
         out[leaf_name] = np.frombuffer(v1.tobytes(), dtype='float64')
+    return out
 
 
 def read_mars(filename, tree='Events', leaf_names=None):

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(
     packages=['read_mars'],
     install_requires=[
         'pyfact>=0.9.4',
+        'pandas',
+        'numpy',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='read_mars',
-    version='0.0.3',
+    version='0.0.4',
     author='Maximilian Nöthe',
     author_email='maximilian.noethe@tu-dortmund.de',
     packages=['read_mars'],


### PR DESCRIPTION
At first I did not trust the returned memory view v1, because it is implemented in a confusing way. It always shows the same shape, regardless of the actual content.
But it does work reliably!

v1 exposes a buffer interface and it might be possible to replace the for loop with np.frombuffer(), as suggested by Maxi Nöthe, saving a little more time. But I don't know how to infer the memory structure of this root thing.