### PR TITLE
fact.path & docopt & a little_overhead

### DIFF
--- a/read_mars/__init__.py
+++ b/read_mars/__init__.py
@@ -1,6 +1,5 @@
 import ROOT
 import pandas as pd
-import os
 import numpy as np
 
 result = ROOT.gSystem.Load('libmars.so')

--- a/read_mars/__init__.py
+++ b/read_mars/__init__.py
@@ -12,15 +12,6 @@ if result != 0:
 from .status_display import StatusDisplay
 
 
-def datepath(base, date):
-    return os.path.join(
-        base,
-        '{:04d}'.format(date.year),
-        '{:02d}'.format(date.month),
-        '{:02d}'.format(date.day),
-    )
-
-
 def is_valid_leaf(leaf):
     '''
     Function to select valid leaves

--- a/read_mars/ganymed_runlist_to_h5py.py
+++ b/read_mars/ganymed_runlist_to_h5py.py
@@ -8,11 +8,12 @@ Arguments:
 '''
 from argparse import ArgumentParser
 import pandas as pd
+import fact
+from functools import partial
 from fact.io import to_h5py
 from tqdm import tqdm
-import os
 
-from . import read_mars, datepath
+from . import read_mars
 
 
 parser = ArgumentParser(description=__doc__)
@@ -29,17 +30,19 @@ def main():
     runs = pd.read_csv(args.runlist)
     runs['night_date'] = pd.to_datetime(runs['night'].astype(str), format='%Y%m%d')
 
+    ganymed_file_path_generator = partial(
+        fact.path.tree_path,
+        prefix=args.ganymed_base,
+        suffix='-summary.root',
+    )
+
     initialised = False
     for idx, run in tqdm(runs.iterrows(), total=len(runs)):
-        night = int('{:%Y%m%d}'.format(run.night_date))
-        base = datepath(args.ganymed_base, run.night_date)
-
-        ganymed_file = os.path.join(
-            base,
-            '{}_{:03d}-summary.root'.format(night, run.run_id)
+        ganymed_file_path = ganymed_file_path_generator(
+            night=int('{:%Y%m%d}'.format(run.night_date)),
+            run=int(run.run_id)
         )
-
-        df = read_mars(ganymed_file, tree='Events')
+        df = read_mars(ganymed_file_path, tree='Events')
         df['night'] = night
         df['run_id'] = run.run_id
 

--- a/read_mars/ganymed_runlist_to_h5py.py
+++ b/read_mars/ganymed_runlist_to_h5py.py
@@ -28,7 +28,8 @@ parser.add_argument(
 def main():
     args = parser.parse_args()
     runs = pd.read_csv(args.runlist)
-    runs['night_date'] = pd.to_datetime(runs['night'].astype(str), format='%Y%m%d')
+    runs['night'] = runs.night.astype(int)
+    runs['run_id'] = runs.run_id.astype(int)
 
     ganymed_file_path_generator = partial(
         fact.path.tree_path,
@@ -38,11 +39,9 @@ def main():
 
     initialised = False
     for idx, run in tqdm(runs.iterrows(), total=len(runs)):
-        night = int('{:%Y%m%d}'.format(run.night_date))
-        run = int(run.run_id)
-        ganymed_file_path = ganymed_file_path_generator(night, run)
+        ganymed_file_path = ganymed_file_path_generator(run.night, run.run_id)
         df = read_mars(ganymed_file_path, tree='Events')
-        df['night'] = night
+        df['night'] = run.night
         df['run_id'] = run.run_id
 
         if not initialised:

--- a/read_mars/ganymed_runlist_to_h5py.py
+++ b/read_mars/ganymed_runlist_to_h5py.py
@@ -1,39 +1,32 @@
 '''
 Convert ganymed file into h5py hdf5
 
-Arguments:
+Usage: ganymed_runlist_to_h5py <runlist> <outputfile>
 
-    RUNLIST: a csv file with columns night,run_id
-    OUTPUTFILE: outputfilename
+Options:
+    --ganymed-base PATH    base path for ganymed filed [default: /gpfs0/fact/processing/data.r18753/ganymed_run/]
+
 '''
-from argparse import ArgumentParser
-import pandas as pd
-import fact
+from docopt import doctopt
 from functools import partial
-from fact.io import to_h5py
+import pandas as pd
 from tqdm import tqdm
+
+import fact
+from fact.io import to_h5py
 
 from . import read_mars
 
 
-parser = ArgumentParser(description=__doc__)
-parser.add_argument('runlist')
-parser.add_argument('outputfile')
-parser.add_argument(
-    '--ganymed-base', dest='ganymed_base',
-    default='/gpfs0/fact/processing/data.r18753/ganymed_run/'
-)
-
-
 def main():
-    args = parser.parse_args()
-    runs = pd.read_csv(args.runlist)
+    args = doctopt(__doc__)
+    runs = pd.read_csv(args['<runlist>'])
     runs['night'] = runs.night.astype(int)
     runs['run_id'] = runs.run_id.astype(int)
 
     ganymed_file_path_generator = partial(
         fact.path.tree_path,
-        prefix=args.ganymed_base,
+        prefix=args['--ganymed-base'],
         suffix='-summary.root',
     )
 
@@ -45,10 +38,10 @@ def main():
         df['run_id'] = run.run_id
 
         if not initialised:
-            to_h5py(args.outputfile, df, key='events', mode='w')
+            to_h5py(args['<outputfile>'], df, key='events', mode='w')
             initialised = True
         else:
-            to_h5py(args.outputfile, df, key='events', mode='a')
+            to_h5py(args['<outputfile>'], df, key='events', mode='a')
 
 
 if __name__ == '__main__':

--- a/read_mars/ganymed_runlist_to_h5py.py
+++ b/read_mars/ganymed_runlist_to_h5py.py
@@ -38,10 +38,9 @@ def main():
 
     initialised = False
     for idx, run in tqdm(runs.iterrows(), total=len(runs)):
-        ganymed_file_path = ganymed_file_path_generator(
-            night=int('{:%Y%m%d}'.format(run.night_date)),
-            run=int(run.run_id)
-        )
+        night = int('{:%Y%m%d}'.format(run.night_date))
+        run = int(run.run_id)
+        ganymed_file_path = ganymed_file_path_generator(night, run)
         df = read_mars(ganymed_file_path, tree='Events')
         df['night'] = night
         df['run_id'] = run.run_id

--- a/read_mars/status_display.py
+++ b/read_mars/status_display.py
@@ -33,8 +33,9 @@ StatusDisplayKey = namedtuple(
 class StatusDisplay:
     def __init__(self, path, transform=True):
         self.path = path
-        self.date = fact.run2dt(self.path.split('/')[-1].split('_')[0]).date()
-        self.run = int(self.path.split('/')[-1].split('_')[1])
+        path_info = fact.path.parse(self.path)
+        self.data = fact.run2dt(str(path_info['night'])).date()
+        self.run = path_info['run']
 
         self.tfile = ROOT.TFile(path)
         self.status_array = self.tfile.Get('MStatusDisplay')

--- a/read_mars/status_display.py
+++ b/read_mars/status_display.py
@@ -60,13 +60,14 @@ class StatusDisplay:
         return self[k]
 
     def df(self):
-        _df = []
-        for k in self.keys():
-            d = k._asdict()
-            d['object'] = self[k]
-            _df.append(d)
-        _df = pd.DataFrame(_df)
-        return _df
+        if not hasattr(self, '_df'):
+            _df = []
+            for k in self.keys():
+                d = k._asdict()
+                d['object'] = self[k]
+                _df.append(d)
+            self._df = pd.DataFrame(_df)
+        return self._df
 
     def __repr__(self):
         return repr(self._df)

--- a/read_mars/tests/test_read_multiple_times.py
+++ b/read_mars/tests/test_read_multiple_times.py
@@ -1,0 +1,24 @@
+import read_mars
+import pkg_resources
+
+
+def test_open():
+
+    path = pkg_resources.resource_filename(
+        'read_mars',
+        'tests/resources/20130930_244_244_B.root')
+
+    with read_mars.StatusDisplay(path) as f:
+        pass
+
+
+def test_read_multiple():
+
+    path = pkg_resources.resource_filename(
+        'read_mars',
+        'tests/resources/20130930_244_244_B.root')
+
+    for i in range(30):
+        with read_mars.StatusDisplay(path) as f:
+            pass
+


### PR DESCRIPTION
possibly too large PR:

 * main point was: use `fact.path` over manual string/path manipulation
 * then I saw `argparse` was used .. many people use docopt or click. argparse is mainly unknown, so I removed it 
* I found somebody called `StatusDisplay.df()` in a project using this package, but `df()` costs a bit (I think) and it is already called in `__init__` and the result is stored in `StatusDisplay._df` (kind of hidden, my bad). I just changed it now, so then one calls `df()` it returns basically `self._df`... 

possibly premature opti ... 