### PR TITLE
Fix13

### DIFF
--- a/read_mars/status_display.py
+++ b/read_mars/status_display.py
@@ -33,8 +33,6 @@ StatusDisplayKey = namedtuple(
 class StatusDisplay:
     def __init__(self, path, transform=True):
         self.path = path
-        self.date = fact.run2dt(self.path.split('/')[-1].split('_')[0]).date()
-        self.run = int(self.path.split('/')[-1].split('_')[1])
 
         self.tfile = ROOT.TFile(path)
         self.status_array = self.tfile.Get('MStatusDisplay')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='read_mars',
-    version='0.0.5',
+    version='0.0.6',
     author='Maximilian Nöthe',
     author_email='maximilian.noethe@tu-dortmund.de',
     packages=['read_mars'],


### PR DESCRIPTION
fixes #13 

Delete run and date from StatusDisplay since they are generated from the filename and not intrinsically part of a StatusDisplay